### PR TITLE
Set deployment caller as initial_owner

### DIFF
--- a/src/voteabout.cairo
+++ b/src/voteabout.cairo
@@ -74,7 +74,8 @@ mod VoteAbout {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, initial_owner: ContractAddress) {
+    fn constructor(ref self: ContractState) {
+        let initial_owner = get_caller_address();
         self.vote_count.write(0);
         self.ownable.initializer(initial_owner);
     }


### PR DESCRIPTION
Removes necessity to specify `initial_owner` at contract deployment. It will be set automatically to caller address.